### PR TITLE
Remove wrong underscore escaping in docs

### DIFF
--- a/lib/logstash/inputs/gelf.rb
+++ b/lib/logstash/inputs/gelf.rb
@@ -30,16 +30,16 @@ class LogStash::Inputs::Gelf < LogStash::Inputs::Base
   #
   # Remapping converts the following GELF fields to Logstash equivalents:
   #
-  # * `full\_message` becomes `event["message"]`.
-  # * if there is no `full\_message`, `short\_message` becomes `event["message"]`.
+  # * `full_message` becomes `event["message"]`.
+  # * if there is no `full_message`, `short_message` becomes `event["message"]`.
   config :remap, :validate => :boolean, :default => true
 
-  # Whether or not to remove the leading `\_` in GELF fields or leave them
+  # Whether or not to remove the leading `_` in GELF fields or leave them
   # in place. (Logstash < 1.2 did not remove them by default.). Note that
   # GELF version 1.1 format now requires all non-standard fields to be added
   # as an "additional" field, beginning with an underscore.
   #
-  # e.g. `\_foo` becomes `foo`
+  # e.g. `_foo` becomes `foo`
   #
   config :strip_leading_underscore, :validate => :boolean, :default => true
 


### PR DESCRIPTION
The docs at http://logstash.net/docs/1.4.2/inputs/gelf show the backslashes, so
the escaping seems wrong.