### PR TITLE
timestamp dropped

### DIFF
--- a/lib/logstash/inputs/gelf.rb
+++ b/lib/logstash/inputs/gelf.rb
@@ -111,7 +111,6 @@ class LogStash::Inputs::Gelf < LogStash::Inputs::Base
       event["source_host"] = client[3]
       if event["timestamp"].is_a?(Numeric)
         event.timestamp = LogStash::Timestamp.at(event["timestamp"])
-        event.remove("timestamp")
       end
       remap_gelf(event) if @remap
       strip_leading_underscore(event) if @strip_leading_underscore


### PR DESCRIPTION
I removed the line which drops the timestamp field.  Timestmp is a default field of the gelf format and should be in the message.  

This solves this issue:
https://github.com/logstash-plugins/logstash-input-gelf/issues/14
