### PR TITLE
Do not remap empty messages

### DIFF
--- a/lib/logstash/inputs/gelf.rb
+++ b/lib/logstash/inputs/gelf.rb
@@ -123,13 +123,13 @@ class LogStash::Inputs::Gelf < LogStash::Inputs::Base
 
   private
   def remap_gelf(event)
-    if event["full_message"]
+    if event["full_message"] && !event["full_message"].empty?
       event["message"] = event["full_message"].dup
       event.remove("full_message")
       if event["short_message"] == event["message"]
         event.remove("short_message")
       end
-    elsif event["short_message"]
+    elsif event["short_message"]  && !event["short_message"].empty?
       event["message"] = event["short_message"].dup
       event.remove("short_message")
     end


### PR DESCRIPTION
When en event includes a `short_message` and an empty `full_message` (like [go-gelf](https://github.com/Graylog2/go-gelf) when writing a single line message), remap sets `message` to an empty string while keeping `short_message`. This commits ensure that in this case `message` will be filled with `short_message` rather than an empty string.