### PR TITLE
Refactor the shutdown

### DIFF
--- a/logstash-input-gelf.gemspec
+++ b/logstash-input-gelf.gemspec
@@ -23,9 +23,11 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "logstash-core", '>= 1.4.0', '< 2.0.0'
 
   s.add_runtime_dependency "gelfd", ["0.2.0"]                 #(Apache 2.0 license)
-  s.add_runtime_dependency "gelf", ["1.3.2"]                  #(MIT license)
   s.add_runtime_dependency 'logstash-codec-plain'
+  s.add_runtime_dependency "stud", "~> 0.0.22"
 
   s.add_development_dependency 'logstash-devutils'
+  s.add_development_dependency "gelf", ["1.3.2"]                  #(MIT license)
+  s.add_development_dependency "flores"
 end
 

--- a/spec/inputs/gelf_spec.rb
+++ b/spec/inputs/gelf_spec.rb
@@ -1,8 +1,24 @@
+# encoding: utf-8
 require "logstash/devutils/rspec/spec_helper"
 require "logstash/inputs/gelf"
+require_relative "../support/helpers"
 require "gelf"
+require "flores/random"
 
-describe "inputs/gelf" do
+describe LogStash::Inputs::Gelf do
+  context "when interrupting the plugin" do
+    let(:port) { Flores::Random.integer(1024..65535) }
+    let(:host) { "127.0.0.1" }
+    let(:chunksize) { 1420 }
+    let(:producer) { InfiniteGelfProducer.new(host, port, chunksize) }
+    let(:config) {  { "host" => host, "port" => port } }
+
+    before { producer.run }
+    after { producer.stop }
+
+
+    it_behaves_like "an interruptible input plugin"
+  end
 
   it "reads chunked gelf messages " do
     port = 12209

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -1,0 +1,18 @@
+# encoding: utf-8
+class InfiniteGelfProducer
+  def initialize(host, port, chunksize)
+    @client = GELF::Notifier.new(host, port, chunksize)
+  end
+
+  def run
+    @producer = Thread.new do
+      while true
+        @client.notify!("short_message" => "hello world")
+      end
+    end
+  end
+
+  def stop
+    @producer.kill
+  end
+end


### PR DESCRIPTION
This PR introduces the changes needed to follow the new shutdown
semantic, it also remove the gelf as a runtime dependencies and move it
as a development dependency since its only used in the tests.

Fixes #17