### PR TITLE
force encoding for source host

### DIFF
--- a/lib/logstash/inputs/gelf.rb
+++ b/lib/logstash/inputs/gelf.rb
@@ -98,7 +98,7 @@ class LogStash::Inputs::Gelf < LogStash::Inputs::Base
 
       event = LogStash::Event.new(LogStash::Json.load(data))
 
-      event["source_host"] = client[3]
+      event["source_host"] = client[3].force_encoding("UTF-8")
       if event["timestamp"].is_a?(Numeric)
         event.timestamp = LogStash::Timestamp.at(event["timestamp"])
         event.remove("timestamp")

--- a/spec/inputs/gelf_spec.rb
+++ b/spec/inputs/gelf_spec.rb
@@ -16,7 +16,6 @@ describe LogStash::Inputs::Gelf do
     before { producer.run }
     after { producer.stop }
 
-
     it_behaves_like "an interruptible input plugin"
   end
 


### PR DESCRIPTION
Running tests on windows showed that potentially the encoding for the source host could come with Windows Encoding rather than UTF 8, which caused the configuration to fail.
