### PR TITLE
Fix the handling of fractional part of the Unix Timestamp, CLA Signed Now..

### DIFF
--- a/lib/logstash/inputs/gelf.rb
+++ b/lib/logstash/inputs/gelf.rb
@@ -110,6 +110,7 @@ class LogStash::Inputs::Gelf < LogStash::Inputs::Base
       if event["timestamp"].is_a?(Numeric)
         # Bundled JRuby with Logstash packages cannot handle fractional
         # parts in a BigDecimal correctly as single argument for ::Time.at()
+        # Workaround: feed it integer & fractional part separately
         if event["timestamp"].is_a?(BigDecimal)
           event.timestamp = LogStash::Timestamp.at(event["timestamp"].to_i(),event["timestamp"].frac() * 1000000)
         else

--- a/lib/logstash/inputs/gelf.rb
+++ b/lib/logstash/inputs/gelf.rb
@@ -108,7 +108,13 @@ class LogStash::Inputs::Gelf < LogStash::Inputs::Base
 
       event["source_host"] = client[3]
       if event["timestamp"].is_a?(Numeric)
-        event.timestamp = LogStash::Timestamp.at(event["timestamp"])
+        # Bundled JRuby with Logstash packages cannot handle fractional
+        # parts in a BigDecimal correctly as single argument for ::Time.at()
+        if event["timestamp"].is_a?(BigDecimal)
+          event.timestamp = LogStash::Timestamp.at(event["timestamp"].to_i(),event["timestamp"].frac() * 1000000)
+        else
+          event.timestamp = LogStash::Timestamp.at(event["timestamp"])
+        end
         event.remove("timestamp")
       end
 


### PR DESCRIPTION
Observed in the bundled .deb packages 2.1.1 & 2.2.0 from
https://www.elastic.co/downloads/logstash, the JRuby interpreter
there cannot correctly deal with a single BigDecimal argument in
::Time.at(), converted to giving 2 arguments so as much of the
fractional part of the BigDecimal can be kept as possible.