### PR TITLE
proper timestamp coercion to preserve microsecond precision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
+## 2.0.3
+ - Fix Timestamp coercion to preserve upto microsecond precision, https://github.com/logstash-plugins/logstash-input-gelf/pull/35
+
 ## 2.0.0
- - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully, 
+ - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully,
    instead of using Thread.raise on the plugins' threads. Ref: https://github.com/elastic/logstash/pull/3895
  - Dependency on logstash-core update to 2.0
 

--- a/logstash-input-gelf.gemspec
+++ b/logstash-input-gelf.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-gelf'
-  s.version         = '2.0.2'
+  s.version         = '2.0.3'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "This input will read GELF messages as events over the network, making it a good choice if you already use Graylog2 today."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/spec/inputs/gelf_spec.rb
+++ b/spec/inputs/gelf_spec.rb
@@ -66,6 +66,84 @@ describe LogStash::Inputs::Gelf do
 
     events.each_with_index do |e, i|
       insist { e["message"] } == messages[i]
+      insist { e["host"] } == Socket.gethostname
+    end
+  end
+
+  context "timestamp coercion" do
+    # these test private methods, this is advisable for now until we roll out this coercion in the Timestamp class
+    # and remove this
+
+    context "integer numeric values" do
+      it "should coerce" do
+        expect(LogStash::Inputs::Gelf.coerce_timestamp(946702800).to_iso8601).to eq("2000-01-01T05:00:00.000Z")
+        expect(LogStash::Inputs::Gelf.coerce_timestamp(946702800).usec).to eq(0)
+      end
+    end
+
+    context "float numeric values" do
+      # using explicit and certainly useless to_f here just to leave no doubt about the numeric type involved
+
+      it "should coerce and preserve millisec precision in iso8601" do
+        expect(LogStash::Inputs::Gelf.coerce_timestamp(946702800.1.to_f).to_iso8601).to eq("2000-01-01T05:00:00.100Z")
+        expect(LogStash::Inputs::Gelf.coerce_timestamp(946702800.12.to_f).to_iso8601).to eq("2000-01-01T05:00:00.120Z")
+        expect(LogStash::Inputs::Gelf.coerce_timestamp(946702800.123.to_f).to_iso8601).to eq("2000-01-01T05:00:00.123Z")
+      end
+
+      it "should coerce and preserve usec precision" do
+        expect(LogStash::Inputs::Gelf.coerce_timestamp(946702800.1.to_f).usec).to eq(100000)
+        expect(LogStash::Inputs::Gelf.coerce_timestamp(946702800.12.to_f).usec).to eq(120000)
+        expect(LogStash::Inputs::Gelf.coerce_timestamp(946702800.123.to_f).usec).to eq(123000)
+
+        # since Java Timestamp in 2.3+ relies on JodaTime which supports only millisec precision
+        # the usec method will only be precise up to millisec.
+        expect(LogStash::Inputs::Gelf.coerce_timestamp(946702800.1234.to_f).usec).to be_within(1000).of(123400)
+        expect(LogStash::Inputs::Gelf.coerce_timestamp(946702800.12345.to_f).usec).to be_within(1000).of(123450)
+        expect(LogStash::Inputs::Gelf.coerce_timestamp(946702800.123456.to_f).usec).to be_within(1000).of(123456)
+      end
+    end
+
+    context "BigDecimal numeric values" do
+      it "should coerce and preserve millisec precision in iso8601" do
+        expect(LogStash::Inputs::Gelf.coerce_timestamp(BigDecimal.new("946702800.1")).to_iso8601).to eq("2000-01-01T05:00:00.100Z")
+        expect(LogStash::Inputs::Gelf.coerce_timestamp(BigDecimal.new("946702800.12")).to_iso8601).to eq("2000-01-01T05:00:00.120Z")
+        expect(LogStash::Inputs::Gelf.coerce_timestamp(BigDecimal.new("946702800.123")).to_iso8601).to eq("2000-01-01T05:00:00.123Z")
+      end
+
+      it "should coerce and preserve usec precision" do
+        expect(LogStash::Inputs::Gelf.coerce_timestamp(BigDecimal.new("946702800.1")).usec).to eq(100000)
+        expect(LogStash::Inputs::Gelf.coerce_timestamp(BigDecimal.new("946702800.12")).usec).to eq(120000)
+        expect(LogStash::Inputs::Gelf.coerce_timestamp(BigDecimal.new("946702800.123")).usec).to eq(123000)
+
+        # since Java Timestamp in 2.3+ relies on JodaTime which supports only millisec precision
+        # the usec method will only be precise up to millisec.
+        expect(LogStash::Inputs::Gelf.coerce_timestamp(BigDecimal.new("946702800.1234")).usec).to be_within(1000).of(123400)
+        expect(LogStash::Inputs::Gelf.coerce_timestamp(BigDecimal.new("946702800.12345")).usec).to be_within(1000).of(123450)
+        expect(LogStash::Inputs::Gelf.coerce_timestamp(BigDecimal.new("946702800.123456")).usec).to be_within(1000).of(123456)
+      end
+    end
+  end
+
+  context "json timestamp coercion" do
+    # these test private methods, this is advisable for now until we roll out this coercion in the Timestamp class
+    # and remove this
+
+    it "should coerce integer numeric json timestamp input" do
+      event = LogStash::Inputs::Gelf.new_event("{\"timestamp\":946702800}", "dummy")
+      expect(event.timestamp.to_iso8601).to eq("2000-01-01T05:00:00.000Z")
+    end
+
+    it "should coerce float numeric value and preserve milliseconds precision in iso8601" do
+      event = LogStash::Inputs::Gelf.new_event("{\"timestamp\":946702800.123}", "dummy")
+      expect(event.timestamp.to_iso8601).to eq("2000-01-01T05:00:00.123Z")
+    end
+
+    it "should coerce float numeric value and preserve usec precision" do
+      # since Java Timestamp in 2.3+ relies on JodaTime which supports only millisec precision
+      # the usec method will only be precise up to millisec.
+
+      event = LogStash::Inputs::Gelf.new_event("{\"timestamp\":946702800.123456}", "dummy")
+      expect(event.timestamp.usec).to be_within(1000).of(123456)
     end
   end
 end


### PR DESCRIPTION
this refactors, extends and replaces #32
this will fix elastic/logstash#4565