### PR TITLE
Make this plugin works under 5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,16 @@
-# 2.0.7
+## 2.0.8
+  - Make the `Event.from_json` return a single element instead of an array and make this plugin works under 5.0
+## 2.0.7
   - Fix failing test caused by reverting Java Event back to Ruby Event
-# 2.0.6
+## 2.0.6
   - Fix plugin crash when Logstash::Json fails to parse a message, https://github.com/logstash-plugins/logstash-input-gelf/pull/27
-# 2.0.5
+## 2.0.5
   - Depend on logstash-core-plugin-api instead of logstash-core, removing the need to mass update plugins on major releases of logstash
-# 2.0.4
+## 2.0.4
   - New dependency requirements for logstash-core for the 5.0 release
-# 2.0.3
+## 2.0.3
  - Fix Timestamp coercion to preserve upto microsecond precision, https://github.com/logstash-plugins/logstash-input-gelf/pull/35
-# 2.0.0
+## 2.0.0
  - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully,
    instead of using Thread.raise on the plugins' threads. Ref: https://github.com/elastic/logstash/pull/3895
  - Dependency on logstash-core update to 2.0

--- a/logstash-input-gelf.gemspec
+++ b/logstash-input-gelf.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-gelf'
-  s.version         = '2.0.7'
+  s.version         = '2.0.8'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "This input will read GELF messages as events over the network, making it a good choice if you already use Graylog2 today."
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/inputs/gelf_spec.rb
+++ b/spec/inputs/gelf_spec.rb
@@ -150,7 +150,8 @@ describe LogStash::Inputs::Gelf do
   context "when an invalid JSON is fed to the listener" do
     subject { LogStash::Inputs::Gelf.new_event(message, "host") }
     let(:message) { "Invalid JSON message" }
-    if LogStash::Event.respond_to?(:from_java)
+
+    if LogStash::Event.respond_to?(:from_json)
       context "default :from_json parser output" do
         it { should be_a(LogStash::Event) }
 


### PR DESCRIPTION
Fix an issue with the java json parse that was return an array instead
of single element, fix the test that were using the wrong condition.

And reformat the changelog to follow the new convention

Fixes #41