### PR TITLE
Update gelfd dependecy to allow uncompressed input

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -25,15 +25,7 @@ This input will read GELF messages as events over the network,
 making it a good choice if you already use Graylog2 today.
 
 The main use case for this input is to leverage existing GELF
-logging libraries such as the GELF log4j appender. A library used
-by this plugin has a bug which prevents it parsing uncompressed data.
-If you use the log4j appender you need to configure it like this to force
-gzip even for small messages:
-
-  <Socket name="logstash" protocol="udp" host="logstash.example.com" port="5001">
-     <GelfLayout compressionType="GZIP" compressionThreshold="1" />
-  </Socket>
-
+logging libraries such as the GELF log4j appender.
 
 
 [id="plugins-{type}s-{plugin}-options"]

--- a/lib/logstash/inputs/gelf.rb
+++ b/lib/logstash/inputs/gelf.rb
@@ -12,16 +12,8 @@ require "json"
 # making it a good choice if you already use Graylog2 today.
 #
 # The main use case for this input is to leverage existing GELF
-# logging libraries such as the GELF log4j appender. A library used
-# by this plugin has a bug which prevents it parsing uncompressed data.
-# If you use the log4j appender you need to configure it like this to force
-# gzip even for small messages:
-#
-#   <Socket name="logstash" protocol="udp" host="logstash.example.com" port="5001">
-#      <GelfLayout compressionType="GZIP" compressionThreshold="1" />
-#   </Socket>
-#
-#
+# logging libraries such as the GELF log4j appender.
+
 class LogStash::Inputs::Gelf < LogStash::Inputs::Base
   config_name "gelf"
 
@@ -73,7 +65,7 @@ class LogStash::Inputs::Gelf < LogStash::Inputs::Base
   end
 
   def register
-    require 'gelfd'
+    require 'gelfd2'
     @port_tcp ||= @port
     @port_udp ||= @port
   end
@@ -202,7 +194,7 @@ class LogStash::Inputs::Gelf < LogStash::Inputs::Base
       end
 
       begin
-        data = Gelfd::Parser.parse(line)
+        data = Gelfd2::Parser.parse(line)
       rescue => ex
         @logger.warn("Gelfd failed to parse a message skipping", :exception => ex, :backtrace => ex.backtrace)
         next

--- a/logstash-input-gelf.gemspec
+++ b/logstash-input-gelf.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
 
-  s.add_runtime_dependency "gelfd", ["0.2.0"]                 #(Apache 2.0 license)
+  s.add_runtime_dependency "gelfd2", ["0.4.1"]                 #(Apache 2.0 license)
   s.add_runtime_dependency 'logstash-codec-plain'
   s.add_runtime_dependency 'stud', '>= 0.0.22', '< 0.1.0'
 


### PR DESCRIPTION
Hi. 

Since gelfd maintainer is not releasing new version of gem for about 2 years (https://github.com/lusis/gelfd/issues/4) I've made a fork and published it to rubygems as gelfd2 (https://github.com/ptqa/gelfd2). I will try to maintain it as long as I can, although there is not a lot of activity.

I've tested this gem on my setup and it seems to work. 
