### PR TITLE
log on exception, and continue event processing

### DIFF
--- a/lib/logstash/inputs/gelf.rb
+++ b/lib/logstash/inputs/gelf.rb
@@ -103,7 +103,7 @@ class LogStash::Inputs::Gelf < LogStash::Inputs::Base
       begin
         data = Gelfd::Parser.parse(line)
       rescue => ex
-        @logger.warn("Gelfd failed to parse a message skipping", :exception => ex, :backtrace => ex.backtrace)
+        @logger.warn("Gelfd failed to parse a message skipping", :exception => ex, :backtrace => ex.backtrace, :line => line)
         next
       end
 
@@ -114,7 +114,7 @@ class LogStash::Inputs::Gelf < LogStash::Inputs::Base
         event = self.class.new_event(data, client[3])
         next if event.nil?
       rescue => ex
-        @logger.warn("Could not create event", :exception => ex, :backtrace => ex.backtrace)
+        @logger.warn("Could not create event", :exception => ex, :backtrace => ex.backtrace, :data => data)
         next
       end
 
@@ -123,7 +123,7 @@ class LogStash::Inputs::Gelf < LogStash::Inputs::Base
         strip_leading_underscore(event) if @strip_leading_underscore
         decorate(event)
       rescue => ex
-        @logger.warn("Could not process event", :exception => ex, :backtrace => ex.backtrace)
+        @logger.warn("Could not process event", :exception => ex, :backtrace => ex.backtrace, :event => event)
         next
       end
 

--- a/lib/logstash/inputs/gelf.rb
+++ b/lib/logstash/inputs/gelf.rb
@@ -103,7 +103,7 @@ class LogStash::Inputs::Gelf < LogStash::Inputs::Base
       begin
         data = Gelfd::Parser.parse(line)
       rescue => ex
-        @logger.warn("Gelfd failed to parse a message skipping", :exception => ex, :backtrace => ex.backtrace, :line => line)
+        @logger.error("Gelfd failed to parse a message, skipping", :exception => ex, :backtrace => ex.backtrace, :line => line)
         next
       end
 
@@ -114,7 +114,7 @@ class LogStash::Inputs::Gelf < LogStash::Inputs::Base
         event = self.class.new_event(data, client[3])
         next if event.nil?
       rescue => ex
-        @logger.warn("Could not create event", :exception => ex, :backtrace => ex.backtrace, :data => data)
+        @logger.error("Could not create event, skipping", :exception => ex, :backtrace => ex.backtrace, :data => data)
         next
       end
 
@@ -123,7 +123,7 @@ class LogStash::Inputs::Gelf < LogStash::Inputs::Base
         strip_leading_underscore(event) if @strip_leading_underscore
         decorate(event)
       rescue => ex
-        @logger.warn("Could not process event", :exception => ex, :backtrace => ex.backtrace, :event => event)
+        @logger.error("Could not process event, skipping", :exception => ex, :backtrace => ex.backtrace, :event => event)
         next
       end
 

--- a/lib/logstash/inputs/gelf.rb
+++ b/lib/logstash/inputs/gelf.rb
@@ -113,9 +113,14 @@ class LogStash::Inputs::Gelf < LogStash::Inputs::Base
       event = self.class.new_event(data, client[3])
       next if event.nil?
 
-      remap_gelf(event) if @remap
-      strip_leading_underscore(event) if @strip_leading_underscore
-      decorate(event)
+      begin
+        remap_gelf(event) if @remap
+        strip_leading_underscore(event) if @strip_leading_underscore
+        decorate(event)
+      rescue => ex
+        @logger.warn("Could not process event", :exception => ex, :backtrace => ex.backtrace)
+        next
+      end
 
       output_queue << event
     end

--- a/lib/logstash/inputs/gelf.rb
+++ b/lib/logstash/inputs/gelf.rb
@@ -110,8 +110,13 @@ class LogStash::Inputs::Gelf < LogStash::Inputs::Base
       # Gelfd parser outputs null if it received and cached a non-final chunk
       next if data.nil?
 
-      event = self.class.new_event(data, client[3])
-      next if event.nil?
+      begin
+        event = self.class.new_event(data, client[3])
+        next if event.nil?
+      rescue => ex
+        @logger.warn("Could not create event", :exception => ex, :backtrace => ex.backtrace)
+        next
+      end
 
       begin
         remap_gelf(event) if @remap


### PR DESCRIPTION
log on exception, and continue event processing.

This should allow for easier debugging ( crash won't be lost in thousands of `SocketError: bind: name or service not known` logs)

and also won't stop logs processing...
