### PR TITLE
Added TCP Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,13 @@
 ---
-sudo: false
-language: ruby
-cache: bundler
-env: 
-rvm:
-- jruby-1.7.25
-matrix:
-  include:
-  - rvm: jruby-9.1.10.0
-    env: LOGSTASH_BRANCH=master
-  - rvm: jruby-9.1.10.0
-    env: LOGSTASH_BRANCH=6.x
-  - rvm: jruby-1.7.25
-    env: LOGSTASH_BRANCH=5.6
-  fast_finish: true
-install: true
-script: ci/build.sh
-jdk: oraclejdk8
+  "sudo": false,
+  "language": "ruby",
+  "cache": "bundler",
+  "rvm": "jruby-1.7.25",
+  "script": [
+    "bundle exec rspec spec"
+  ],
+  "jdk": "oraclejdk8",
+  "before_install": [],
+  "group": "stable",
+  "dist": "precise",
+  "os": "linux"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
----
+{
   "sudo": false,
   "language": "ruby",
   "cache": "bundler",
@@ -11,3 +11,4 @@
   "group": "stable",
   "dist": "precise",
   "os": "linux"
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,11 @@
   "sudo": false,
   "language": "ruby",
   "cache": "bundler",
+  "env": null,
   "rvm": "jruby-1.7.25",
-  "script": [
-    "bundle exec rspec spec"
-  ],
+  "install": true,
+  "script": "ci/build.sh",
   "jdk": "oraclejdk8",
-  "before_install": [],
   "group": "stable",
   "dist": "precise",
   "os": "linux"

--- a/lib/logstash/inputs/gelf.rb
+++ b/lib/logstash/inputs/gelf.rb
@@ -6,6 +6,7 @@ require "logstash/timestamp"
 require "stud/interval"
 require "date"
 require "socket"
+require "json"
 
 # This input will read GELF messages as events over the network,
 # making it a good choice if you already use Graylog2 today.
@@ -29,9 +30,10 @@ class LogStash::Inputs::Gelf < LogStash::Inputs::Base
   # The IP address or hostname to listen on.
   config :host, :validate => :string, :default => "0.0.0.0"
 
-  # The port to listen on. Remember that ports less than 1024 (privileged
+  # The ports to listen on. Remember that ports less than 1024 (privileged
   # ports) may require root to use.
-  config :port, :validate => :number, :default => 12201
+  config :port_tcp, :validate => :number, :default => 12201
+  config :port_udp, :validate => :number, :default => 12201
 
   # Whether or not to remap the GELF message fields to Logstash event fields or
   # leave them intact.
@@ -58,6 +60,15 @@ class LogStash::Inputs::Gelf < LogStash::Inputs::Base
   TAGS_FIELD = "tags"
   PARSE_FAILURE_TAG = "_jsonparsefailure"
   PARSE_FAILURE_LOG_MESSAGE = "JSON parse failure. Falling back to plain-text"
+  
+  # Whether or not to use TCP or/and UDP
+  config :use_tcp, :validate => :boolean, :default => true
+  config :use_udp, :validate => :boolean, :default => true
+  
+  
+  # Whether to capture the hostname or numeric address of the incoming connection
+  # Defaults to hostname
+  config :use_numeric_client_addr, :validate => :boolean, :default => false
 
   public
   def initialize(params)
@@ -68,13 +79,23 @@ class LogStash::Inputs::Gelf < LogStash::Inputs::Base
   public
   def register
     require 'gelfd'
+    @tcp = nil
+    @udp = nil
   end # def register
 
   public
   def run(output_queue)
     begin
-      # udp server
-      udp_listener(output_queue)
+      if @use_tcp
+        tcp_thr = Thread.new(output_queue) do |output_queue|
+          tcp_listener(output_queue)
+        end
+      end
+      if @use_udp
+        udp_thr = Thread.new(output_queue) do |output_queue|
+          udp_listener(output_queue)
+        end
+	  end
     rescue => e
       unless stop?
         @logger.warn("gelf listener died", :exception => e, :backtrace => e.backtrace)
@@ -82,6 +103,8 @@ class LogStash::Inputs::Gelf < LogStash::Inputs::Base
         retry unless stop?
       end
     end # begin
+    udp_thr.join
+    tcp_thr.join
   end # def run
 
   public
@@ -91,11 +114,83 @@ class LogStash::Inputs::Gelf < LogStash::Inputs::Base
   end
 
   private
+  def tcp_listener(output_queue)
+
+    @logger.warn("Starting gelf listener (tcp) ...", :address => "#{@host}:#{@port_tcp}")
+
+    if @tcp.nil?
+      @tcp = TCPServer.new(@host, @port_tcp)
+    end
+
+    while !@shutdown_requested
+      Thread.new(@tcp.accept) do |client|
+        @logger.debug? && @logger.debug("Gelf (tcp): Accepting connection from:  #{client.peeraddr[2]}:#{client.peeraddr[1]}")
+
+        begin
+          while !client.nil? && !client.eof?
+          
+            begin # Read from socket
+              @data_in = client.gets("\u0000")
+            rescue => ex
+              @logger.warn("Gelf (tcp): failed gets from client socket:", :exception => ex, :backtrace => ex.backtrace)
+            end 
+ 
+             if @data_in.nil?
+              @logger.warn("Gelf (tcp): socket read succeeded, but data is nil.  Skipping.")
+              next
+            end
+           
+            # data received.  Remove trailing \0
+            @data_in[-1] == "\u0000" && @data_in = @data_in[0...-1]
+            begin # Parse JSON
+              @jsonObj = JSON.parse(@data_in)
+	      #@logger.warn("OK: " + @data_in)
+            rescue => ex
+              #@logger.warn("Gelf (tcp): failed to parse a message. Skipping: " + @data_in, :exception => ex, :backtrace => ex.backtrace)
+              next
+            end
+           
+            begin  # Create event
+              event = LogStash::Event.new(@jsonObj)
+              event.set("source_host", @use_numeric_client_addr && client.addr(:numeric) || client.addr(:hostname))
+              if event.get("timestamp").is_a?(Numeric)
+                #event["@timestamp"] = Time.at(event["timestamp"]).gmtime
+                event.set("timestamp", LogStash::Timestamp.at(event.get("timestamp")))
+                event.remove("timestamp")
+              end
+              #event = self.class.new_event(data, @use_numeric_client_addr && client.addr(:numeric) || client.addr(:hostname))
+              remap_gelf(event) if @remap
+              strip_leading_underscore(event) if @strip_leading_underscore
+              decorate(event)
+              output_queue << event
+            rescue => ex
+              @logger.warn("Gelf (tcp): failed to create event from json object. Skipping: " + @jsonObj.to_s, :exception => ex, :backtrace => ex.backtrace)
+            end 
+
+          end # while client
+          @logger.debug? && @logger.debug("Gelf (tcp): Closing client connection")
+          client.close
+          client = nil
+        rescue => ex
+          @logger.warn("Gelf (tcp): client socket failed.", :exception => ex, :backtrace => ex.backtrace)
+        ensure
+          if !client.nil? 
+            @logger.debug? && @logger.debug("Gelf (tcp): Ensuring client is closed")
+            client.close
+            client = nil
+          end
+        end # begin client
+      end  # Thread.new
+    end # @shutdown_requested
+    
+  end
+
+  private
   def udp_listener(output_queue)
-    @logger.info("Starting gelf listener", :address => "#{@host}:#{@port}")
+    @logger.info("Starting gelf listener (udp) ...", :address => "#{@host}:#{@port_udp}")
 
     @udp = UDPSocket.new(Socket::AF_INET)
-    @udp.bind(@host, @port)
+    @udp.bind(@host, @port_udp)
 
     while !stop?
       line, client = @udp.recvfrom(8192)


### PR DESCRIPTION
You can now use gelf protocol with a TCP connection too. You can choose to use TCP and/or UDP by setting use_tcp and use_udp flags to true or false. You can also choose  different ports to listen on (port_tcp and port_udp flags). Note: you can use the same port for TCP and UDP.

Tested with an AWS cloud big setup (lot of aws server instances with nxlog connected to: logstash -> elasticsearch cluster -> kibana).
It works!
