### PR TITLE
Change default receive buffer size from 8192 to 65536

### DIFF
--- a/lib/logstash/inputs/gelf.rb
+++ b/lib/logstash/inputs/gelf.rb
@@ -185,7 +185,7 @@ class LogStash::Inputs::Gelf < LogStash::Inputs::Base
 
     while !stop?
       begin
-        line, client = @udp.recvfrom(8192)
+        line, client = @udp.recvfrom(65536)
       rescue => e
         if !stop?
           @logger.error("Caught exception while reading from UDP socket", :exception => e)


### PR DESCRIPTION
in a similar way logstash-input-udp has
(see https://github.com/logstash-plugins/logstash-input-udp/commit/bf64e5900270dd7304829deee91633c8d016b8e3)

UDP packets have a size limit of 64k, not 8k.
IMHO There's no reason to live with an artificial limit besides saving 64k-8k=56k of RAM.
