### PR TITLE
Fix crash when receive a BigDecimal inside `_@timestamp`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.3.1
+  - Fix: safely coerce the value of `_@timestamp` to don't crash the plugin [#67](https://github.com/logstash-plugins/logstash-input-gelf/pull/67)
+
 ## 3.3.0
   - Updated library to gelfd2 [#48](https://github.com/logstash-plugins/logstash-input-gelf/pull/48)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 3.3.1
-  - Fix: safely coerce the value of `_@timestamp` to don't crash the plugin [#67](https://github.com/logstash-plugins/logstash-input-gelf/pull/67)
+  - Fix: safely coerce the value of `_@timestamp` to avoid crashing the plugin [#67](https://github.com/logstash-plugins/logstash-input-gelf/pull/67)
 
 ## 3.3.0
   - Updated library to gelfd2 [#48](https://github.com/logstash-plugins/logstash-input-gelf/pull/48)

--- a/lib/logstash/inputs/gelf.rb
+++ b/lib/logstash/inputs/gelf.rb
@@ -284,10 +284,8 @@ class LogStash::Inputs::Gelf < LogStash::Inputs::Base
   end
 
   def coerce_timestamp_carefully(value)
+    # catch float numbers in 123.567 or 0.123567e3 forms
+    value = BigDecimal.new(value) if value.kind_of?(String) && value.match(/\A([0-9]+(\.[0-9]+)?)|(0\.[0-9]+e[0-9])\z/)
     LogStash::Timestamp.at(value)
-  rescue TypeError => e
-    # maybe it's a BigDecimal?
-    coerced_value = BigDecimal.new(value)
-    LogStash::Timestamp.at(coerced_value.to_i, coerced_value.frac * 1000000)
   end
 end

--- a/lib/logstash/inputs/gelf.rb
+++ b/lib/logstash/inputs/gelf.rb
@@ -281,7 +281,6 @@ class LogStash::Inputs::Gelf < LogStash::Inputs::Base
   rescue => e
     @logger.warn("Failed to move field `#{source_field}` to `#{destination_field}`: #{e.message}")
     event.tag("_gelf_move_field_failure")
-    event.set("[@metadata][error_reason]", e.message)
   end
 
   def coerce_timestamp_carefully(value)

--- a/lib/logstash/inputs/gelf.rb
+++ b/lib/logstash/inputs/gelf.rb
@@ -241,8 +241,9 @@ class LogStash::Inputs::Gelf < LogStash::Inputs::Base
   # @param timestamp [Numeric] a Numeric (integer, float or bigdecimal) timestampo representation
   # @return [LogStash::Timestamp] the proper LogStash::Timestamp representation
   def self.coerce_timestamp(timestamp)
-    # bug in JRuby prevents correctly parsing a BigDecimal fractional part, see https://github.com/elastic/logstash/issues/4565
-    timestamp.is_a?(BigDecimal) ? LogStash::Timestamp.at(timestamp.to_i, timestamp.frac * 1000000) : LogStash::Timestamp.at(timestamp)
+    # prevent artificial precision from being injected by floats
+    timestamp = timestamp.rationalize if timestamp.kind_of?(Float)
+    LogStash::Timestamp.at(timestamp)
   end
 
   def self.parse(json)
@@ -286,6 +287,6 @@ class LogStash::Inputs::Gelf < LogStash::Inputs::Base
   def coerce_timestamp_carefully(value)
     # catch float numbers in 123.567 or 0.123567e3 forms
     value = BigDecimal.new(value) if value.kind_of?(String) && value.match(/\A([0-9]+(\.[0-9]+)?)|(0\.[0-9]+e[0-9])\z/)
-    LogStash::Timestamp.at(value)
+    self.class.coerce_timestamp(value)
   end
 end

--- a/lib/logstash/inputs/gelf.rb
+++ b/lib/logstash/inputs/gelf.rb
@@ -206,8 +206,17 @@ class LogStash::Inputs::Gelf < LogStash::Inputs::Base
       event = self.class.new_event(data, client[3])
       next if event.nil?
 
-      remap_gelf(event) if @remap
-      strip_leading_underscore(event) if @strip_leading_underscore
+      begin
+        remap_gelf(event) if @remap
+        strip_leading_underscore(event) if @strip_leading_underscore
+      rescue => e
+        if !stop?
+          @logger.error("Caught exception while striping leading underscores", :exception => e)
+        end
+        next
+      end
+
+
       decorate(event)
 
       output_queue << event

--- a/lib/logstash/inputs/gelf.rb
+++ b/lib/logstash/inputs/gelf.rb
@@ -286,7 +286,7 @@ class LogStash::Inputs::Gelf < LogStash::Inputs::Base
 
   def coerce_timestamp_carefully(value)
     # catch float numbers in 123.567 or 0.123567e3 forms
-    value = BigDecimal.new(value) if value.kind_of?(String) && value.match(/\A([0-9]+(\.[0-9]+)?)|(0\.[0-9]+e[0-9])\z/)
+    value = BigDecimal(value) if value.kind_of?(String)
     self.class.coerce_timestamp(value)
   end
 end

--- a/lib/logstash/inputs/gelf.rb
+++ b/lib/logstash/inputs/gelf.rb
@@ -250,7 +250,7 @@ class LogStash::Inputs::Gelf < LogStash::Inputs::Base
   # @param timestamp [Numeric] a Numeric (integer, float or bigdecimal) timestampo representation
   # @return [LogStash::Timestamp] the proper LogStash::Timestamp representation
   def self.coerce_timestamp(timestamp)
-    # bug in JRuby prevents correcly parsing a BigDecimal fractional part, see https://github.com/elastic/logstash/issues/4565
+    # bug in JRuby prevents correctly parsing a BigDecimal fractional part, see https://github.com/elastic/logstash/issues/4565
     timestamp.is_a?(BigDecimal) ? LogStash::Timestamp.at(timestamp.to_i, timestamp.frac * 1000000) : LogStash::Timestamp.at(timestamp)
   end
 

--- a/lib/logstash/inputs/gelf.rb
+++ b/lib/logstash/inputs/gelf.rb
@@ -206,17 +206,8 @@ class LogStash::Inputs::Gelf < LogStash::Inputs::Base
       event = self.class.new_event(data, client[3])
       next if event.nil?
 
-      begin
-        remap_gelf(event) if @remap
-        strip_leading_underscore(event) if @strip_leading_underscore
-      rescue => ex
-        if !stop?
-          @logger.warn("Gelf (udp): striping leading underscores failed.", :exception => ex, :backtrace => ex.backtrace)
-        end
-        next
-      end
-
-
+      remap_gelf(event) if @remap
+      strip_leading_underscore(event) if @strip_leading_underscore
       decorate(event)
 
       output_queue << event

--- a/logstash-input-gelf.gemspec
+++ b/logstash-input-gelf.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'logstash-codec-plain'
   s.add_runtime_dependency 'stud', '>= 0.0.22', '< 0.1.0'
 
-  s.add_development_dependency 'logstash-devutils'
+  s.add_development_dependency 'logstash-devutils', '>= 2.3'
   s.add_development_dependency "gelf", ["3.0.0"]                  #(MIT license)
   s.add_development_dependency "flores"
 end

--- a/logstash-input-gelf.gemspec
+++ b/logstash-input-gelf.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-gelf'
-  s.version         = '3.3.0'
+  s.version         = '3.3.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads GELF-format messages from Graylog2 as events"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/inputs/gelf_spec.rb
+++ b/spec/inputs/gelf_spec.rb
@@ -77,7 +77,7 @@ describe LogStash::Inputs::Gelf do
     let(:config) { { "port" => port, "host" => host } }
     let(:queue) { Queue.new }
 
-    subject { described_class.new(config) }
+    subject(:gelf_input) { described_class.new(config) }
 
     before(:each) do
       subject.register

--- a/spec/inputs/gelf_spec.rb
+++ b/spec/inputs/gelf_spec.rb
@@ -142,7 +142,7 @@ describe LogStash::Inputs::Gelf do
 
     context "integer numeric values" do
       it "should coerce" do
-        expect(LogStash::Inputs::Gelf.coerce_timestamp(946702800).to_iso8601).to eq("2000-01-01T05:00:00.000Z")
+        expect(LogStash::Inputs::Gelf.coerce_timestamp(946702800)).to be_a_logstash_timestamp_equivalent_to("2000-01-01T05:00:00.000Z")
         expect(LogStash::Inputs::Gelf.coerce_timestamp(946702800).usec).to eq(0)
       end
     end
@@ -151,9 +151,9 @@ describe LogStash::Inputs::Gelf do
       # using explicit and certainly useless to_f here just to leave no doubt about the numeric type involved
 
       it "should coerce and preserve millisec precision in iso8601" do
-        expect(LogStash::Inputs::Gelf.coerce_timestamp(946702800.1.to_f).to_iso8601).to eq("2000-01-01T05:00:00.100Z")
-        expect(LogStash::Inputs::Gelf.coerce_timestamp(946702800.12.to_f).to_iso8601).to eq("2000-01-01T05:00:00.120Z")
-        expect(LogStash::Inputs::Gelf.coerce_timestamp(946702800.123.to_f).to_iso8601).to eq("2000-01-01T05:00:00.123Z")
+        expect(LogStash::Inputs::Gelf.coerce_timestamp(Rational(946702800.1).truncate(3)).to_iso8601).to eq("2000-01-01T05:00:00.100Z")
+        expect(LogStash::Inputs::Gelf.coerce_timestamp(Rational(946702800.12).truncate(3)).to_iso8601).to eq("2000-01-01T05:00:00.120Z")
+        expect(LogStash::Inputs::Gelf.coerce_timestamp(Rational(946702800.123).truncate(3)).to_iso8601).to eq("2000-01-01T05:00:00.123Z")
       end
 
       it "should coerce and preserve usec precision" do
@@ -196,7 +196,7 @@ describe LogStash::Inputs::Gelf do
 
     it "should coerce integer numeric json timestamp input" do
       event = LogStash::Inputs::Gelf.new_event("{\"timestamp\":946702800}", "dummy")
-      expect(event.timestamp.to_iso8601).to eq("2000-01-01T05:00:00.000Z")
+      expect(event.timestamp).to be_a_logstash_timestamp_equivalent_to("2000-01-01T05:00:00.000Z")
     end
 
     it "should coerce float numeric value and preserve milliseconds precision in iso8601" do

--- a/spec/inputs/gelf_spec.rb
+++ b/spec/inputs/gelf_spec.rb
@@ -41,7 +41,13 @@ describe LogStash::Inputs::Gelf do
 
     before(:each) do
       subject.register
-      Thread.new { subject.run(queue) }
+      @runner = Thread.new { subject.run(queue) }
+    end
+
+    after(:each) do
+      subject.do_stop
+      @runner.kill
+      @runner.join
     end
 
     it "processes them" do
@@ -81,7 +87,13 @@ describe LogStash::Inputs::Gelf do
 
     before(:each) do
       subject.register
-      Thread.new { subject.run(queue) }
+      @runner = Thread.new { subject.run(queue) }
+    end
+
+    after(:each) do
+      subject.do_stop
+      @runner.kill
+      @runner.join
     end
 
     context "with valid value" do

--- a/spec/inputs/gelf_spec.rb
+++ b/spec/inputs/gelf_spec.rb
@@ -156,9 +156,9 @@ describe LogStash::Inputs::Gelf do
       # using explicit and certainly useless to_f here just to leave no doubt about the numeric type involved
 
       it "should coerce and preserve millisec precision in iso8601" do
-        expect(LogStash::Inputs::Gelf.coerce_timestamp(Rational(946702800.1).truncate(3)).to_iso8601).to eq("2000-01-01T05:00:00.100Z")
-        expect(LogStash::Inputs::Gelf.coerce_timestamp(Rational(946702800.12).truncate(3)).to_iso8601).to eq("2000-01-01T05:00:00.120Z")
-        expect(LogStash::Inputs::Gelf.coerce_timestamp(Rational(946702800.123).truncate(3)).to_iso8601).to eq("2000-01-01T05:00:00.123Z")
+        expect(LogStash::Inputs::Gelf.coerce_timestamp(946702800.1.to_f)).to be_a_logstash_timestamp_equivalent_to("2000-01-01T05:00:00.100Z")
+        expect(LogStash::Inputs::Gelf.coerce_timestamp(946702800.12.to_f)).to be_a_logstash_timestamp_equivalent_to("2000-01-01T05:00:00.120Z")
+        expect(LogStash::Inputs::Gelf.coerce_timestamp(946702800.123.to_f)).to be_a_logstash_timestamp_equivalent_to("2000-01-01T05:00:00.123Z")
       end
 
       it "should coerce and preserve usec precision" do

--- a/spec/inputs/gelf_spec.rb
+++ b/spec/inputs/gelf_spec.rb
@@ -134,8 +134,6 @@ describe LogStash::Inputs::Gelf do
         expect(e.get("message")).to eq("msg1")
         event_tags = e.to_hash['tags']
         expect(event_tags).to include("_gelf_move_field_failure")
-        error_reason = e.to_hash_with_metadata['@metadata']['error_reason']
-        expect(error_reason).to start_with("invalid value for BigDecimal")
         expect(e.get("host")).to eq(Socket.gethostname)
 
         e = queue.pop

--- a/spec/inputs/gelf_spec.rb
+++ b/spec/inputs/gelf_spec.rb
@@ -129,7 +129,10 @@ describe LogStash::Inputs::Gelf do
         e = queue.pop
         expect(e.get("message")).to eq("msg1")
         event_tags = e.to_hash['tags']
-        expect(event_tags).to include("_gelf_move_field_failure")
+        aggregate_failures "tag and leave bad value in place" do
+          expect(event_tags).to include("_gelf_move_field_failure")
+          expect(e.get('_@timestamp')).to eq("foo")
+        end
         expect(e.get("host")).to eq(Socket.gethostname)
 
         e = queue.pop

--- a/spec/inputs/gelf_spec.rb
+++ b/spec/inputs/gelf_spec.rb
@@ -104,7 +104,7 @@ describe LogStash::Inputs::Gelf do
 
         e = queue.pop
         expect(e.get("message")).to eq("msg1")
-        expect(e.timestamp.to_iso8601).to eq("2000-01-01T05:00:00.100Z")
+        expect(e.timestamp).to be_a_logstash_timestamp_equivalent_to("2000-01-01T05:00:00.100Z")
         expect(e.get("host")).to eq(Socket.gethostname)
 
         e = queue.pop


### PR DESCRIPTION
The UDP server crashes when receives a GELF message like that `{"full_message": "my message", "_@timestamp": 12345678889}`

I wrote a test case to show that behavior.

Thanks

----

<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
Safe parsing of `_@timestamp` to avoid crashing the plugin and Logstash

## What does this PR do?
This PR safely cast the values of `_@timestamp` field in GELF and in case of error skip the event, avoiding Logstash crash

## Why is it important/What is the impact to the user?
Permit to handle correctly the numerical values in `_@timestamp` without stopping Logstash process in case of error.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
- Checkout this branch
- Run Logstash configuring this plugin in `Gemfile`:
  -  gem "logstash-input-gelf", :path => "/path_to/logstash-input-gelf"
  - `bin/logstash-plugin install --no-verify`
- configure a `pipeline.conf` as:
```
input {
  gelf { port => "3333" }
}

output { 
  stdout { 
    codec => rubydebug { metadata => true } 
  }
}
```
- provide some input from another shell:
```
echo -n '{ "version": "1.1", "host": "example.org", "short_message": "A short message", "level": 5, "_@timestamp": "foo" }' | nc -u -w0 127.0.0.1 3333
```
- Logstash skip the message and doesn't crash

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->
A user send GELF messages in the form:
```json
{ "version": "1.1", "host": "example.org", "short_message": "A short message", "level": 5, "_@timestamp": "foo" }
```
and the parsing of such payload can't crash Logstash.


## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

```
[2021-11-16T09:22:14,240][WARN ][org.logstash.Event       ][main][a966e44cc4978c04ea63b0e0fba28400454ae6cbcc52f24abaade32528a0a352] Unrecognized @timestamp value type=class org.jruby.RubyFixnum
warning: thread "Ruby-0-Thread-34: :1" terminated with exception (report_on_exception is true):
TypeError: wrong argument type Integer (expected LogStash::Timestamp)
                       set at org/logstash/ext/JrubyEventExtLibrary.java:122
  strip_leading_underscore at /home/andrea/workspace/logstash_andsel/vendor/bundle/jruby/2.5.0/gems/logstash-input-gelf-3.3.0/lib/logstash/inputs/gelf.rb:273
                      each at org/jruby/RubyArray.java:1821
  strip_leading_underscore at /home/andrea/workspace/logstash_andsel/vendor/bundle/jruby/2.5.0/gems/logstash-input-gelf-3.3.0/lib/logstash/inputs/gelf.rb:271
              udp_listener at /home/andrea/workspace/logstash_andsel/vendor/bundle/jruby/2.5.0/gems/logstash-input-gelf-3.3.0/lib/logstash/inputs/gelf.rb:210
                       run at /home/andrea/workspace/logstash_andsel/vendor/bundle/jruby/2.5.0/gems/logstash-input-gelf-3.3.0/lib/logstash/inputs/gelf.rb:79
[2021-11-16T09:22:14,265][ERROR][logstash.javapipeline    ][main][a966e44cc4978c04ea63b0e0fba28400454ae6cbcc52f24abaade32528a0a352] A plugin had an unrecoverable error. Will restart this plugin.
  Pipeline_id:main
  Plugin: <LogStash::Inputs::Gelf port=>3333, id=>"a966e44cc4978c04ea63b0e0fba28400454ae6cbcc52f24abaade32528a0a352", enable_metric=>true, codec=><LogStash::Codecs::Plain id=>"plain_26d156d8-c393-41b3-8cde-08392c473c27", enable_metric=>true, charset=>"UTF-8">, host=>"0.0.0.0", remap=>true, strip_leading_underscore=>true, use_tcp=>false, use_udp=>true>
  Error: wrong argument type Integer (expected LogStash::Timestamp)
  Exception: TypeError
  Stack: org/logstash/ext/JrubyEventExtLibrary.java:122:in `set'
/home/andrea/workspace/logstash_andsel/vendor/bundle/jruby/2.5.0/gems/logstash-input-gelf-3.3.0/lib/logstash/inputs/gelf.rb:273:in `block in strip_leading_underscore'
org/jruby/RubyArray.java:1821:in `each'
/home/andrea/workspace/logstash_andsel/vendor/bundle/jruby/2.5.0/gems/logstash-input-gelf-3.3.0/lib/logstash/inputs/gelf.rb:271:in `strip_leading_underscore'
/home/andrea/workspace/logstash_andsel/vendor/bundle/jruby/2.5.0/gems/logstash-input-gelf-3.3.0/lib/logstash/inputs/gelf.rb:210:in `udp_listener'
/home/andrea/workspace/logstash_andsel/vendor/bundle/jruby/2.5.0/gems/logstash-input-gelf-3.3.0/lib/logstash/inputs/gelf.rb:79:in `block in run'
[2021-11-16T09:22:14,314][FATAL][logstash.runner          ] An unexpected error occurred! {:error=>#<TypeError: wrong argument type Integer (expected LogStash::Timestamp)>, :backtrace=>["org/logstash/ext/JrubyEventExtLibrary.java:122:in `set'", "/home/andrea/workspace/logstash_andsel/vendor/bundle/jruby/2.5.0/gems/logstash-input-gelf-3.3.0/lib/logstash/inputs/gelf.rb:273:in `block in strip_leading_underscore'", "org/jruby/RubyArray.java:1821:in `each'", "/home/andrea/workspace/logstash_andsel/vendor/bundle/jruby/2.5.0/gems/logstash-input-gelf-3.3.0/lib/logstash/inputs/gelf.rb:271:in `strip_leading_underscore'", "/home/andrea/workspace/logstash_andsel/vendor/bundle/jruby/2.5.0/gems/logstash-input-gelf-3.3.0/lib/logstash/inputs/gelf.rb:210:in `udp_listener'", "/home/andrea/workspace/logstash_andsel/vendor/bundle/jruby/2.5.0/gems/logstash-input-gelf-3.3.0/lib/logstash/inputs/gelf.rb:79:in `block in run'"]}
[2021-11-16T09:22:14,322][FATAL][org.logstash.Logstash    ] Logstash stopped processing because of an error: (SystemExit) exit
org.jruby.exceptions.SystemExit: (SystemExit) exit
	at org.jruby.RubyKernel.exit(org/jruby/RubyKernel.java:747) ~[jruby-complete-9.2.20.0.jar:?]
	at org.jruby.RubyKernel.exit(org/jruby/RubyKernel.java:710) ~[jruby-complete-9.2.20.0.jar:?]
	at home.andrea.workspace.logstash_andsel.lib.bootstrap.environment.<main>(/home/andrea/workspace/logstash_andsel/lib/bootstrap/environment.rb:94) ~[?:?]

```
