### PR TITLE
fix: restore separate BigDecimal routing to avoid JRuby panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 3.3.2
-  - Fix: avoid panic when handling very-large exponent-notation `_@timestamp` values
+  - Fix: avoid panic when handling very-large exponent-notation `_@timestamp` values [#71](https://github.com/logstash-plugins/logstash-input-gelf/pull/71)
 
 ## 3.3.1
   - Fix: safely coerce the value of `_@timestamp` to avoid crashing the plugin [#67](https://github.com/logstash-plugins/logstash-input-gelf/pull/67)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.3.2
+  - Fix: avoid panic when handling very-large exponent-notation `_@timestamp` values
+
 ## 3.3.1
   - Fix: safely coerce the value of `_@timestamp` to avoid crashing the plugin [#67](https://github.com/logstash-plugins/logstash-input-gelf/pull/67)
 

--- a/lib/logstash/inputs/gelf.rb
+++ b/lib/logstash/inputs/gelf.rb
@@ -243,7 +243,9 @@ class LogStash::Inputs::Gelf < LogStash::Inputs::Base
   def self.coerce_timestamp(timestamp)
     # prevent artificial precision from being injected by floats
     timestamp = timestamp.rationalize if timestamp.kind_of?(Float)
-    LogStash::Timestamp.at(timestamp)
+
+    # bug in JRuby prevents correcly parsing a BigDecimal fractional part, see https://github.com/elastic/logstash/issues/4565
+    timestamp.is_a?(BigDecimal) ? LogStash::Timestamp.at(timestamp.to_i, timestamp.frac * 1000000) : LogStash::Timestamp.at(timestamp)
   end
 
   def self.parse(json)

--- a/logstash-input-gelf.gemspec
+++ b/logstash-input-gelf.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-gelf'
-  s.version         = '3.3.1'
+  s.version         = '3.3.2'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads GELF-format messages from Graylog2 as events"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/inputs/gelf_spec.rb
+++ b/spec/inputs/gelf_spec.rb
@@ -176,9 +176,9 @@ describe LogStash::Inputs::Gelf do
 
     context "BigDecimal numeric values" do
       it "should coerce and preserve millisec precision in iso8601" do
-        expect(LogStash::Inputs::Gelf.coerce_timestamp(BigDecimal.new("946702800.1")).to_iso8601).to eq("2000-01-01T05:00:00.100Z")
-        expect(LogStash::Inputs::Gelf.coerce_timestamp(BigDecimal.new("946702800.12")).to_iso8601).to eq("2000-01-01T05:00:00.120Z")
-        expect(LogStash::Inputs::Gelf.coerce_timestamp(BigDecimal.new("946702800.123")).to_iso8601).to eq("2000-01-01T05:00:00.123Z")
+        expect(LogStash::Inputs::Gelf.coerce_timestamp(BigDecimal.new("946702800.1"))).to be_a_logstash_timestamp_equivalent_to("2000-01-01T05:00:00.100Z")
+        expect(LogStash::Inputs::Gelf.coerce_timestamp(BigDecimal.new("946702800.12"))).to be_a_logstash_timestamp_equivalent_to("2000-01-01T05:00:00.120Z")
+        expect(LogStash::Inputs::Gelf.coerce_timestamp(BigDecimal.new("946702800.123"))).to be_a_logstash_timestamp_equivalent_to("2000-01-01T05:00:00.123Z")
       end
 
       it "should coerce and preserve usec precision" do
@@ -206,7 +206,12 @@ describe LogStash::Inputs::Gelf do
 
     it "should coerce float numeric value and preserve milliseconds precision in iso8601" do
       event = LogStash::Inputs::Gelf.new_event("{\"timestamp\":946702800.123}", "dummy")
-      expect(event.timestamp.to_iso8601).to eq("2000-01-01T05:00:00.123Z")
+      expect(event.timestamp).to be_a_logstash_timestamp_equivalent_to("2000-01-01T05:00:00.123Z")
+    end
+
+    it "should coerce exponent-notation timestamps" do
+      event = LogStash::Inputs::Gelf.new_event("{\"timestamp\":1.660873462488E13}", "dummy")
+      expect(event.timestamp).to be_a_logstash_timestamp_equivalent_to("+528279-11-06T19:48:00Z")
     end
 
     it "should coerce float numeric value and preserve usec precision" do


### PR DESCRIPTION
Adds a test case for large exponent-notation timestamp fields and restores the separate routing of `BigDecimal`-decoded timestamps.

Relates: #67
Resolves: #70
